### PR TITLE
fixes #2 wrong encoding with value 128

### DIFF
--- a/contracts/RLPEncode.sol
+++ b/contracts/RLPEncode.sol
@@ -18,7 +18,7 @@ library RLPEncode {
      */
     function encodeBytes(bytes memory self) internal pure returns (bytes memory) {
         bytes memory encoded;
-        if (self.length == 1 && uint8(self[0]) <= 128) {
+        if (self.length == 1 && uint8(self[0]) < 128) {
             encoded = self;
         } else {
             encoded = concat(encodeLength(self.length, 128), self);

--- a/test/rlpencode.js
+++ b/test/rlpencode.js
@@ -82,4 +82,11 @@ contract('RLPEncode', (accounts) => {
       assert.equal(encoded, '0x80', '"false" not correctly encoded');
     });
   });
+  it('should encode 128 correctly', () => {
+    return RLPEncode.deployed().then((instance) => {
+      return instance.encodeUint(128);
+    }).then((encoded) => {
+      assert.equal(encoded, '0x8180', ' Integer 128 not correctly encoded');
+    });
+  });
 });


### PR DESCRIPTION
According to https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/#definition
RLP encoding is defined as follows:
- For a single byte whose value is in the [0x00, 0x7f] (decimal [0, 127]) range, that byte is its own RLP encoding.
- Otherwise, if a string is 0-55 bytes long, the RLP encoding consists of a single byte with value 0x80 (dec. 128) plus the length of the string followed by the string. The range of the first byte is thus [0x80, 0xb7] (dec. [128, 183]).

The old code included 128 in the first definition (<=128) instead of excluding it (<128) that it falls in the second definition.