### PR TITLE
Revert more gracefully when a list element is null bytes

### DIFF
--- a/contracts/RLPEncode.sol
+++ b/contracts/RLPEncode.sol
@@ -189,6 +189,7 @@ library RLPEncode {
         uint len;
         uint i;
         for (i = 0; i < _list.length; i++) {
+            require(_list[i].length > 0, "An item in the list to be RLP encoded is null.");
             len += _list[i].length;
         }
 


### PR DESCRIPTION
Better than the underflow reversion that occurs otherwise. Change tested & works.